### PR TITLE
Update to .Net Framework 4.8, fix crash on date change

### DIFF
--- a/CCTime.csproj
+++ b/CCTime.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.8" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CCTime</RootNamespace>
     <AssemblyName>CCTime</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -37,12 +37,12 @@
     <ApplicationIcon>brick.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="INIFileParser">
-      <HintPath>..\packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
+    <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
+      <HintPath>packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="ObjectListView">
-      <HintPath>..\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>
+    <Reference Include="ObjectListView, Version=2.9.1.1072, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
+      <HintPath>packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/DataManager.cs
+++ b/DataManager.cs
@@ -163,29 +163,28 @@ namespace CCTime
 			}
 		}
 
-		public static bool DayExsists( DateTime dt )
+		public static bool DayExists( DateTime dt )
 		{
 			return TaskManager.taskData.ContainsKey( dt.ToString( "yyyy-MM-dd" ) );
 		}
 
 		public static List<Task> GetDay( DateTime dt )
 		{
-			if( !TaskManager.taskData.ContainsKey( dt.ToString( "yyyy-MM-dd" ) ) ) return null;
-			return TaskManager.taskData[dt.ToString( "yyyy-MM-dd" )];
+			if (DayExists( dt ))
+			{
+				return TaskManager.taskData[dt.ToString("yyyy-MM-dd")];
+			}
+			else
+			{
+				// add today, if not present, by cloning previous date
+				return AddDay(dt, GetPreviousDate(dt, true));
+			}
 		}
 
 		public static List<Task> GetToday()
 		{
 			var today = DateTime.Now;
-			if( DayExsists( today ) )
-			{
-				return TaskManager.taskData[today.ToString( "yyyy-MM-dd" )];
-			}
-			else
-			{
-				// add today, if not present, by cloning previous date
-				return AddDay( today, GetPreviousDate( today, true ) );
-			}
+			return GetDay( today );
 		}
 
 		public static string GetNextDate( DateTime dt )

--- a/FormDateSelect.cs
+++ b/FormDateSelect.cs
@@ -24,11 +24,11 @@ namespace CCTime
 
 			if(this.ChooseFromAvailable)
 			{
-				return TaskManager.DayExsists( dt );
+				return TaskManager.DayExists( dt );
 			}
 			else
 			{
-				return !TaskManager.DayExsists( dt );
+				return !TaskManager.DayExists( dt );
 			}
 		}
 

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ini-parser" version="2.5.2" targetFramework="net40" />
-  <package id="ObjectListView.Official" version="2.9.1" targetFramework="net20" />
+  <package id="ini-parser" version="2.5.2" targetFramework="net48" />
+  <package id="ObjectListView.Official" version="2.9.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Hi,

This is to fix an issue. If you leave the app running and put the computer to sleep or hibernation, it will crash upon resume when clicking on its icon on the system tray.

The .Net Framework isn't supported anymore so I updated to 4.8 at the same time.